### PR TITLE
Added OSGi bundle generation using bnd

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-SymbolicName: org.quicktheories.quicktheories
+Import-Package: javax.annotation.*;resolution:=optional, *
+-exportcontents:\
+	*
+
+-sources: false

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,26 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.0</version>


### PR DESCRIPTION
Added configuration to automatically generate QuickTheories as an OSGi bundle so it can be used in OSGi integration tests.