### PR TITLE
Typo in the first README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ You can run QuickTheories from JUnit, TestNG or any other test framework.
 Here we are using JUnit 
 
 ```java
-import static org.quicktheories.quicktheories.QuickTheory.qt;
-import static org.quicktheories.quicktheories.generators.SourceDSL.*;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.*;
 
 public class SomeTests {
 


### PR DESCRIPTION
Just a typo, but annoying because in one of the first examples, often just copied and pasted as is...