### PR TITLE
Add Gen and DSL for maps

### DIFF
--- a/core/src/main/java/org/quicktheories/WithQuickTheories.java
+++ b/core/src/main/java/org/quicktheories/WithQuickTheories.java
@@ -15,6 +15,7 @@ import org.quicktheories.generators.IntegersDSL;
 import org.quicktheories.generators.ListsDSL;
 import org.quicktheories.generators.LocalDatesDSL;
 import org.quicktheories.generators.LongsDSL;
+import org.quicktheories.generators.MapsDSL;
 import org.quicktheories.generators.SourceDSL;
 import org.quicktheories.generators.StringsDSL;
 
@@ -50,6 +51,10 @@ public interface WithQuickTheories {
 
   public default ListsDSL lists() {
     return SourceDSL.lists();
+  }
+
+  public default MapsDSL maps() {
+    return SourceDSL.maps();
   }
 
   public default ArraysDSL arrays() {

--- a/core/src/main/java/org/quicktheories/generators/Maps.java
+++ b/core/src/main/java/org/quicktheories/generators/Maps.java
@@ -1,0 +1,47 @@
+package org.quicktheories.generators;
+
+import org.quicktheories.api.AsString;
+import org.quicktheories.core.Gen;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Maps {
+    static <K,V> Gen<Map<K,V>> boundedMapsOf(Gen<K> kg, Gen<V> vg, int minimumSize, int maximumSize) {
+        return mapsOf(kg, vg, defaultMap(), minimumSize, maximumSize);
+    }
+
+    public static <K,V> Collector<Map.Entry<K,V>, ?, Map<K,V>> defaultMap() {
+        return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    static <K,V> Gen<Map<K,V>> mapsOf(Gen<K> kg, Gen<V> vg,
+                                      Collector<Map.Entry<K,V>, ?, Map<K,V>> collector,
+                                      int minimumSize, int maximumSize) {
+        Gen<Map<K,V>> gen = prng -> {
+            Gen<Integer> sizes = Generate.range(minimumSize, maximumSize);
+            int size = sizes.generate(prng);
+            return Stream.generate(() -> kg.generate(prng))
+                    .distinct()
+                    .map(k -> mapEntry(k, vg.generate(prng)))
+                    .limit(size)
+                    .collect(collector);
+
+        };
+        return gen.describedAs(mapDescriber(kg::asString, vg::asString));
+    }
+
+    private static <K,V> AsString<Map<K,V>> mapDescriber(Function<K, String> kd, Function<V, String> vd) {
+        return list -> list.entrySet().stream()
+                .map(e -> "(" + kd.apply(e.getKey()) + "," + vd.apply(e.getValue()) + ")")
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    static <K,V> Map.Entry<K,V> mapEntry(K k, V v) {
+        return Collections.singletonMap(k, v).entrySet().iterator().next();
+    }
+}

--- a/core/src/main/java/org/quicktheories/generators/MapsDSL.java
+++ b/core/src/main/java/org/quicktheories/generators/MapsDSL.java
@@ -1,0 +1,78 @@
+package org.quicktheories.generators;
+
+import org.quicktheories.core.Gen;
+
+import java.util.Map;
+
+/**
+ * A Class for creating Map Sources that will produce Map objects of either
+ * fixed or bounded size.
+ */
+public class MapsDSL {
+
+    /**
+     * Creates a ListGeneratorBuilder.
+     *
+     * @param <K> key type to generate
+     * @param <V> value type to generate
+     * @return a MapGeneratorBuilder of type K,V
+     */
+    public static <K,V> MapGeneratorBuilder<K,V> of(Gen<K> kg, Gen<V> vg) {
+        return new MapGeneratorBuilder<>(kg, vg);
+    }
+
+    /**
+     * MapGeneratorBuilder enables the creation of Sources for Maps of fixed and
+     * bounded size, where no Collector is specified. A MapGeneratorBuilder can
+     * be used to create a TypedListGeneratorBuilder, where the Collector is
+     * specified.
+     *
+     * @param <K> key type to generate
+     * @param <V> value type to generate
+     */
+    public static class MapGeneratorBuilder<K,V> {
+        final Gen<K> kg;
+        final Gen<V> vg;
+
+        public MapGeneratorBuilder(final Gen<K> kg, final Gen<V> vg) {
+            this.kg = kg;
+            this.vg = vg;
+        }
+
+        /**
+         * Generates a Map of objects, where the size of the Map is fixed
+         *
+         * @param size size of lists to generate
+         * @return a Source of Mists of type K,V
+         */
+        public Gen<Map<K,V>> ofSize(int size) {
+            return ofSizeBetween(size, size);
+        }
+
+        /**
+         * Generates a Map of objects, where the size of the Map is bounded by
+         * minimumSize and maximumSize
+         *
+         * @param minSize inclusive minimum size of Map
+         * @param maxSize inclusive maximum size of Map
+         * @return a Source of Lists of type T
+         */
+        public Gen<Map<K,V>> ofSizeBetween(int minSize, int maxSize) {
+            checkBoundedArguments(minSize, maxSize);
+            return Maps.boundedMapsOf(kg, vg, minSize, maxSize);
+        }
+    }
+
+    private static void checkBoundedArguments(int minSize, int maxSize) {
+        ArgumentAssertions.checkArguments(minSize <= maxSize,
+                "The minSize (%s) is longer than the maxSize(%s)",
+                minSize, maxSize);
+        checkSizeNotNegative(minSize);
+    }
+
+    private static void checkSizeNotNegative(int size) {
+        ArgumentAssertions.checkArguments(size >= 0,
+                "The size of a Map cannot be negative; %s is not an accepted argument",
+                size);
+    }
+}

--- a/core/src/main/java/org/quicktheories/generators/SourceDSL.java
+++ b/core/src/main/java/org/quicktheories/generators/SourceDSL.java
@@ -30,6 +30,10 @@ public class SourceDSL {
     return new ListsDSL();
   }
 
+  public static MapsDSL maps() {
+    return new MapsDSL();
+  }
+
   public static ArraysDSL arrays() {
     return new ArraysDSL();
   }

--- a/core/src/test/java/org/quicktheories/dogfood/MapsDSLTest.java
+++ b/core/src/test/java/org/quicktheories/dogfood/MapsDSLTest.java
@@ -1,0 +1,24 @@
+package org.quicktheories.dogfood;
+
+import org.junit.Test;
+import org.quicktheories.WithQuickTheories;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class MapsDSLTest implements WithQuickTheories {
+  @Test
+  public void fixedSizeMapsHaveFixedSize() {
+    qt()
+    .forAll(maps().of(integers().all(), integers().all()).ofSize(2))
+    .check(m -> m.size() == 2);
+  }
+  
+  @Test
+  public void boundedSizeMapsHaveBoundedSize() {
+    qt()
+    .forAll(maps().of(integers().all(), integers().all()).ofSizeBetween(1, 2))
+    .check(m -> m.size() >= 1 && m.size() <= 2);
+  }
+}


### PR DESCRIPTION
This adds a generator for maps, similar to the one for lists. Currently it only supports collecting to the default Collectors.toMap() implementation, but it would be simple to add support for generating others.

The mapEntry() code creates a singleton map and throws it away, but I'm not sure creating a new Map.Entry class just for internal use would be great.