### PR TITLE
Add method to support dependent generators in forAll

### DIFF
--- a/core/src/test/java/org/quicktheories/dogfood/ListsDSLTest.java
+++ b/core/src/test/java/org/quicktheories/dogfood/ListsDSLTest.java
@@ -12,15 +12,17 @@ public class ListsDSLTest implements WithQuickTheories {
   @Test
   public void fixedSizeListsHaveFixedSize() {
     qt()
-    .forAll(lists().of(integers().all()).ofSize(2))
-    .check( l -> l.size() == 2);
+    .forAll(integers().between(0, 10))
+    .withPrecursorGen(n -> lists().of(integers().all()).ofSize(n))
+    .check((n, l) -> l.size() == n);
   }
   
   @Test
   public void boundedSizeListsHaveBoundedSize() {
     qt()
-    .forAll(lists().of(integers().all()).ofSizeBetween(1, 2))
-    .check( l -> l.size() >= 1 && l.size() <= 2);
+    .forAll(integers().between(0, 10), integers().between(0, 10))
+    .withPrecursorGen((min, extra) -> lists().of(integers().all()).ofSizeBetween(min, min + extra))
+    .check((min, extra, l) -> l.size() >= min && l.size() <= min + extra);
   }
   
   @Test

--- a/core/src/test/java/org/quicktheories/dogfood/MapsDSLTest.java
+++ b/core/src/test/java/org/quicktheories/dogfood/MapsDSLTest.java
@@ -7,15 +7,17 @@ public class MapsDSLTest implements WithQuickTheories {
   @Test
   public void fixedSizeMapsHaveFixedSize() {
     qt()
-    .forAll(maps().of(integers().all(), integers().all()).ofSize(2))
-    .check(m -> m.size() == 2);
+    .forAll(integers().between(0, 10))
+    .withPrecursorGen(n -> maps().of(integers().all(), integers().all()).ofSize(n))
+    .check((n, m) -> m.size() == n);
   }
   
   @Test
   public void boundedSizeMapsHaveBoundedSize() {
     qt()
-    .forAll(maps().of(integers().all(), integers().all()).ofSizeBetween(1, 2))
-    .check(m -> m.size() >= 1 && m.size() <= 2);
+    .forAll(integers().between(0, 10), integers().between(0, 10))
+    .withPrecursorGen((min, extra) -> maps().of(integers().all(), integers().all()).ofSizeBetween(min, min + extra))
+    .check((min, extra, m) -> m.size() >= min && m.size() <= min + extra);
   }
  
 }


### PR DESCRIPTION
This isn't meant to be committed as-is, it's a work in progress but wanted to get some feedback on it, especially if you think it's a good idea.

While writing https://github.com/ncredinburgh/QuickTheories/pull/33, I wondered why the ListDSLTest hard-coded the numbers 2 and 1 for the length of the lists rather than being generated too. I suspect the answer is at least partially that there isn't an elegant way to generate a value, generate a dependent value, and then use both in the test.


This code adds an equivalent to asWithPrecursor() with a Gen-producing function, as flatMap() is to map(). What do you think of the idea of this? Also, "withPrecursorGen" could do with a better name.

If this seems useful, I can add it to the other TheoryBuilders too. In the size-between tests generating (min, extra) and adding them in both the list generator and the check isn't as nice as it could be. I should be able to make it so you can chain withPrecursorGen, so it could be something like:

```
.forAll(integers().between(0, 10))
.withPrecursorGen(min -> integers().between(0, 10).map(n -> n + min))
.withPrecursorGen((min, max) -> lists().of(integers().all()).ofSizeBetween(min, max))
.check((min, extra, l) -> l.size() >= min && l.size() <= max);
```