### PR TITLE
fix package in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ public class SomeTests {
 }
 ```
 
-The static import `org.quicktheories.quicktheories.QuickTheory.qt` provides access to the QuickTheories DSL.
+The static import `org.quicktheories.QuickTheory.qt` provides access to the QuickTheories DSL.
 
-The static import `org.quicktheories.quicktheories.generators.SourceDSL.*` provides access to a DSL that allows valid inputs to be defined.
+The static import `org.quicktheories.generators.SourceDSL.*` provides access to a DSL that allows valid inputs to be defined.
 
 This property looks pretty simple, it just checks that adding two integers always produces a number greater than 0.
 


### PR DESCRIPTION
I didn't verify this, but I assume the doubled package component _must_ be wrong.