### PR TITLE
Profiles and Testing Time Configuration Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,57 @@ e.g.
 
 Gens provide a number of methods that allows them to be mapped to different types or combined with other Gens. All these operations preserve assumptions and allow the resulting types to be shrunk without the need for any additional code.
 	
+## Profiles
+
+Often its desirable to re-use configurations across multiple properties without duplication and to be
+able to control which configurations are used in different environments. This can be accomplished by 
+using profiles. Profiles are named configurations that are scoped to a given Java class. They can be
+shared across test classes or be local to a JUnit test class. Setting the profile to use is done through
+ the `QT_PROFILE` system property. If no profile is set, the default profile is used. 
+
+To define a profile, register it:
+```java
+import org.quicktheories.core.Profile;
+public class SomeTests implements WithQuickTheories {
+    static {
+        Profile.registerProfile(SomeTests.class, "ci", s -> s.withExamples(10000));
+        Profile.registerProfile(SomeTests.class, "dev", s -> s.withExamples(10));
+    }
+}
+``` 
+
+For each class with registered profiles, a default profile can also be registered 
+(otherwise the QuickTheories defaults are used). The default profile can also be
+explicitly selected with `-DQT_PROFILE=default`:
+
+```java
+Profile.registerDefaultProfile(SomeTests.class, s -> s.withExamples(10));
+```
+
+
+Properties must opt-in to using profiles using `withRegisteredProfiles`:
+```java
+@Test
+public void someProperty() {
+    qt().withRegisteredProfiles(SomeTests.class)
+        .forAll(...)
+        .check(...)
+}
+```
+
+An explicit profile can also be set:
+```java
+@Test
+public void someProperty() {
+    qt().withProfile(SomeTests.class, "ci")
+        .forAll(...)
+        .check(...)
+}
+```
+
+Any configuration changes made after the call to `withProfile` or `withRegisteredProfiles` will take
+precedence over values set in the profile. 
+	
 ## Modifying the falsification output
 
 Values produces by the sources DSL should provide clear falsification messages.

--- a/core/src/main/java/org/quicktheories/core/Configuration.java
+++ b/core/src/main/java/org/quicktheories/core/Configuration.java
@@ -13,11 +13,40 @@ public abstract class Configuration {
 
   private static final int DEFAULT_NO_ATTEMPTS = 10;
   private static final int DEFAULT_NO_EXAMPLES = 1000;
-  
+  private static final int DEFAULT_TESTING_TIME_MILLIS = -1;
+
+  public final static String PROFILE = "QT_PROFILE";
   public final static String SEED = "QT_SEED";
   public final static String EXAMPLES = "QT_EXAMPLES";
   public final static String SHRINKS = "QT_SHRINKS";
+  public final static String TESTING_TIME = "QT_TESTING_TIME";
   public final static String GENERATE_ATTEMPTS = "QT_ATTEMPTS";
+
+  /**
+   * Returns the initial profile to use for a {@link org.quicktheories.QuickTheory} taking into account
+   * profiles
+   *
+   * @return a Strategy that takes into account the active profile and default values
+   */
+  public static Strategy initialStrategy(Class<?> testClass) {
+    // if there is a profile name given, use it to look up a profile strategy and use it if it exists,
+    // otherwise use the registered default if it exists, otherwise use the system strategy
+    return Optional.ofNullable(System.getProperty(PROFILE))
+            .map(p -> Configuration.profileStrategy(testClass, p))
+            .orElseGet(() -> Configuration.defaultStrategy(testClass));
+
+  }
+
+  public static Strategy profileStrategy(Class<?> testClass, String profile) {
+    // if there is a profile of the given name, use it, otherwise use the registered default if it exists, otherwise
+    // use the system strategy
+    return Profile.getProfile(testClass, profile).map(f -> f.apply(systemStrategy())).orElseGet(() -> Configuration.defaultStrategy(testClass));
+  }
+
+  public static Strategy defaultStrategy(Class<?> testClass) {
+    // if there is a default profile registered use it, otherwise use the system strategy
+    return Profile.getDefaultProfile(testClass).map(f -> f.apply(systemStrategy())).orElseGet(Configuration::systemStrategy);
+  }
 
   /**
    * Sets the strategy for the corresponding QuickTheory. Default values are set
@@ -26,7 +55,7 @@ public abstract class Configuration {
    * @return a Strategy
    */
   public static Strategy systemStrategy() {
-    return new Strategy(defaultPRNG(pickSeed()), pickExamples(), pickShrinks(), pickAttempts(),
+    return new Strategy(defaultPRNG(pickSeed()), pickExamples(), pickTestingTimeMillis(), pickShrinks(), pickAttempts(),
         new ExceptionReporter(), pickGuidance());
   }
 
@@ -46,6 +75,12 @@ public abstract class Configuration {
     Optional<String> userValue = Optional
         .ofNullable(System.getProperty(EXAMPLES));
     return userValue.map(Integer::valueOf).orElseGet(() -> DEFAULT_NO_EXAMPLES);
+  }
+
+  private static long pickTestingTimeMillis() {
+    Optional<String> userValue = Optional
+            .ofNullable(System.getProperty(TESTING_TIME));
+    return userValue.map(Integer::valueOf).orElseGet(() -> DEFAULT_TESTING_TIME_MILLIS);
   }
 
   private static long pickSeed() {
@@ -69,5 +104,14 @@ public abstract class Configuration {
    */
   public static PseudoRandom defaultPRNG(long seed) {
     return new XOrShiftPRNG(seed);
+  }
+
+  public static <T> Class<T> ensureLoaded(Class<T> klass) {
+    try {
+      Class.forName(klass.getName(), true, klass.getClassLoader());
+    } catch (ClassNotFoundException e) {
+      throw new AssertionError(e);  // Can't happen
+    }
+    return klass;
   }
 }

--- a/core/src/main/java/org/quicktheories/core/Profile.java
+++ b/core/src/main/java/org/quicktheories/core/Profile.java
@@ -1,0 +1,42 @@
+package org.quicktheories.core;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public class Profile {
+
+    private static final Map<Class<?>, Map<String, Function<Strategy, Strategy>>> profiles = new ConcurrentHashMap<>();
+    private static final String DEFAULT = "default";
+
+    public static void registerDefaultProfile(Class<?> cls, Function<Strategy, Strategy> profile) {
+        registerProfile(cls, DEFAULT, profile);
+    }
+
+    public static void registerProfile(Class<?> cls, String name, Function<Strategy, Strategy> profile) {
+        Map<String, Function<Strategy, Strategy>> perClass = profiles.get(cls);
+        if (perClass == null) {
+            Map<String, Function<Strategy, Strategy>> newPerClass = new ConcurrentHashMap<>();
+            perClass = profiles.putIfAbsent(cls, newPerClass);
+            if (perClass == null)
+                perClass = newPerClass;
+        }
+
+        if (perClass.putIfAbsent(name, profile) != null)
+            throw new IllegalArgumentException(String.format("Profile %s already exists for class %s", name, cls.getSimpleName()));
+    }
+
+    public static Optional<Function<Strategy, Strategy>> getDefaultProfile(Class<?> cls) {
+        return getProfile(cls, DEFAULT);
+    }
+
+    public static Optional<Function<Strategy, Strategy>> getProfile(Class<?> cls, String name) {
+        return Optional.ofNullable(profiles.get(cls)).flatMap(perClass -> Optional.ofNullable(perClass.get(name)));
+    }
+
+    static void clearProfiles() {
+        profiles.clear();
+    }
+
+}

--- a/core/src/main/java/org/quicktheories/impl/Core.java
+++ b/core/src/main/java/org/quicktheories/impl/Core.java
@@ -55,6 +55,8 @@ class Core {
     ArrayDeque<long[]> toVisit = new ArrayDeque<>();
 
     Distribution<T> distribution;
+
+    long endTime = System.currentTimeMillis() + config.testingTimeMillis();
     for (int i = 0; i != config.examples(); i++) {
       if (toVisit.isEmpty()) {
         distribution = randomDistribution;
@@ -81,7 +83,10 @@ class Core {
       
       guidance.exampleComplete();
 
-    }   
+      if (config.testingTimeMillis() > 0 && System.currentTimeMillis() > endTime)
+        break;
+    }
+
     return Optional.empty();
   }
 

--- a/core/src/test/java/com/example/ExampleProfiles.java
+++ b/core/src/test/java/com/example/ExampleProfiles.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import org.quicktheories.core.Profile;
+
+import java.util.concurrent.TimeUnit;
+
+public class ExampleProfiles {
+
+    static {
+        Profile.registerProfile(ExampleProfiles.class,"ci", s -> s.withUnlimitedExamples().withTestingTime(1, TimeUnit.MINUTES));
+        Profile.registerDefaultProfile(ExampleProfiles.class, s -> s.withExamples(1000));
+    }
+
+}

--- a/core/src/test/java/org/quicktheories/core/ProfileTest.java
+++ b/core/src/test/java/org/quicktheories/core/ProfileTest.java
@@ -1,0 +1,72 @@
+package org.quicktheories.core;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.quicktheories.WithQuickTheories;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProfileTest implements WithQuickTheories {
+
+    static class Scope1 {
+    }
+
+    static class Scope2 {
+    }
+
+    @Before
+    public void before() {
+        Profile.clearProfiles();
+    }
+
+    @Test
+    public void testIsScopedToClass() {
+        int v1 = 1, v2 = 2;
+        Profile.registerDefaultProfile(Scope1.class, s -> s.withExamples(v1));
+        Profile.registerDefaultProfile(Scope2.class, s -> s.withExamples(v2));
+
+        Optional<Function<Strategy, Strategy>> p1 = Profile.getDefaultProfile(Scope1.class);
+        Optional<Function<Strategy, Strategy>> p2 = Profile.getDefaultProfile(Scope2.class);
+
+        assertThat(p1).isNotEmpty();
+        assertThat(p2).isNotEmpty();
+        assertThat(p1.get().apply(Configuration.systemStrategy()).examples()).isEqualTo(v1);
+        assertThat(p2.get().apply(Configuration.systemStrategy()).examples()).isEqualTo(v2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testReRegistrationThrowsException() {
+        Profile.registerDefaultProfile(Scope1.class, s -> s.withExamples(1));
+        Profile.registerDefaultProfile(Scope1.class, s -> s.withExamples(1));
+    }
+
+    @Test
+    public void propertyCanLoadRegisteredProperties() {
+        int numExamples = 4;
+        AtomicInteger examplesRun = new AtomicInteger(0); // don't really need concurrency safe object but its a simple mutable container
+        Profile.registerDefaultProfile(Scope1.class, s -> s.withExamples(numExamples));
+        qt().withRegisteredProfiles(Scope1.class).forAll(integers().all()).check(i -> {
+            examplesRun.incrementAndGet();
+            return true;
+        });
+        assertThat(examplesRun.get()).isEqualTo(numExamples);
+    }
+
+    @Test
+    public void propertyCanLoadExplicitProfile() {
+        int numExamples = 5;
+        AtomicInteger examplesRun = new AtomicInteger(0); // don't really need concurrency safe object but its a simple mutable container
+        Profile.registerProfile(Scope1.class, "ci", s -> s.withExamples(numExamples));
+        Profile.registerDefaultProfile(Scope1.class, s -> s.withExamples(1));
+        qt().withProfile(Scope1.class, "ci").forAll(integers().all()).check(i -> {
+            examplesRun.incrementAndGet();
+            return true;
+        });
+        assertThat(examplesRun.get()).isEqualTo(numExamples);
+    }
+
+}

--- a/core/src/test/java/org/quicktheories/highlevel/ComponentTest.java
+++ b/core/src/test/java/org/quicktheories/highlevel/ComponentTest.java
@@ -20,7 +20,7 @@ import org.quicktheories.dsl.TheoryBuilder;
 abstract class ComponentTest<T> {
   
   protected Reporter reporter = mock(Reporter.class);
-  protected Strategy defaultStrategy = new Strategy(Configuration.defaultPRNG(2), 1000, 10000, 10,
+  protected Strategy defaultStrategy = new Strategy(Configuration.defaultPRNG(2), 1000, 0, 10000, 10,
       this.reporter, prng -> new NoGuidance());
 
   public TheoryBuilder<T> assertThatFor(Gen<T> generator) {

--- a/core/src/test/java/org/quicktheories/highlevel/IntegersComponentTest.java
+++ b/core/src/test/java/org/quicktheories/highlevel/IntegersComponentTest.java
@@ -63,7 +63,7 @@ public class IntegersComponentTest extends ComponentTest<Integer> implements Wit
   public void shouldFindAValueEqualToTargetWithDomainBelowZeroMarker() {
     int target = -1;
     assertThatFor(integers().from(-6).upToAndIncluding(-1),
-        new Strategy(Configuration.defaultPRNG(0), 1, 2, 1, this.reporter, prng -> new NoGuidance()))
+        new Strategy(Configuration.defaultPRNG(0), 1, 0, 2, 1, this.reporter, prng -> new NoGuidance()))
             .check(i -> i > target);
     smallestValueIsEqualTo(target);
   }

--- a/core/src/test/java/org/quicktheories/impl/QTTester.java
+++ b/core/src/test/java/org/quicktheories/impl/QTTester.java
@@ -31,7 +31,7 @@ public class QTTester {
   private Reporter r = mock(Reporter.class);
 
   public QuickTheory qt(long seed) {
-    Strategy s = new Strategy(Configuration.defaultPRNG(seed), 100, 10000, 10, r, prng -> new NoGuidance());
+    Strategy s = new Strategy(Configuration.defaultPRNG(seed), 100, 0, 10000, 10, r, prng -> new NoGuidance());
     return org.quicktheories.QuickTheory.qt(() -> s);
   }
 

--- a/core/src/test/java/org/quicktheories/impl/TheoryRunnerTest.java
+++ b/core/src/test/java/org/quicktheories/impl/TheoryRunnerTest.java
@@ -38,7 +38,7 @@ public class TheoryRunnerTest {
 
   @Before
   public void setup() {
-    strategy = new Strategy(Configuration.defaultPRNG(0), 100, 100, 10, reporter, guidance);
+    strategy = new Strategy(Configuration.defaultPRNG(0), 100, 0, 100, 10, reporter, guidance);
   }
 
   @Test
@@ -99,7 +99,7 @@ public class TheoryRunnerTest {
   @Test
   public void shouldReportInitialSeed() {
     long seed = 42;
-    strategy = new Strategy(Configuration.defaultPRNG(seed), 10, 10, 10, reporter, guidance);
+    strategy = new Strategy(Configuration.defaultPRNG(seed), 10, 0, 10, 10, reporter, guidance);
     testee = makeTesteeFor(arbitrary().pick(1));
     testee.check(i -> false);
     verify(reporter, times(1)).falisification(eq(seed), anyInt(), anyInt(),
@@ -116,7 +116,7 @@ public class TheoryRunnerTest {
   @Test
   public void shouldReportNumberOfFoundExamplesWhenValuesExhausted() {
     int numberOfExamples = 3;
-    strategy = new Strategy(Configuration.defaultPRNG(0), numberOfExamples, 0, 10,
+    strategy = new Strategy(Configuration.defaultPRNG(0), numberOfExamples, 0, 0, 10,
         reporter, guidance);
     testee = makeTesteeFor(
         arbitrary().pick(1, 2, 1, 1, 1).assuming(


### PR DESCRIPTION
* add ability to create, register, and select profiles (named configurations)
* support running a property for a maximum amount of time in addition to
or instead of a maximum number of examples

I've included these as one patch to reduce conflicts since they touch the same code. If review is easier with them separate please let me know. 