### PR TITLE
Adds support for frequency generators

### DIFF
--- a/core/src/main/java/org/quicktheories/generators/Generate.java
+++ b/core/src/main/java/org/quicktheories/generators/Generate.java
@@ -1,14 +1,16 @@
 package org.quicktheories.generators;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.List;
+import java.math.BigInteger;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.quicktheories.api.AsString;
+import org.quicktheories.api.Pair;
 import org.quicktheories.core.Gen;
+import org.quicktheories.core.RandomnessSource;
 import org.quicktheories.impl.Constraint;
 
 public class Generate {
@@ -78,6 +80,167 @@ public class Generate {
   }
 
   /**
+   * Returns a generator that provides a value from a generator chosen with probability
+   * in proportion to the weight supplied in the {@link Pair}. Shrinking is
+   * towards the first non-zero weight in the list. At least one generator must have
+   * a positive weight and non-positive generators will never be chosen.
+   *
+   * @param mandatory Generator to sample from
+   * @param others Other generators to sample
+   * @param <T> Type to generate
+   * @return A gen of T
+   */
+  @SafeVarargs
+  public static <T> Gen<T> frequency(Pair<Integer, Gen<T>> mandatory,
+                                         Pair<Integer, Gen<T>> ... others) {
+
+    return frequency(FrequencyGen.makeGeneratorList(mandatory, others));
+  }
+
+  /**
+   * Returns a generator that provides a value from a generator chosen with probability
+   * in proportion to the weight supplied in the {@link Pair}. Shrinking is
+   * towards the first non-zero weight in the list. At least one generator must have
+   * a positive weight and non-positive generators will never be chosen.
+   *
+   * @param weightedGens pairs of weight and generators to sample in proportion to their weighting
+   * @param <T> Type to generate
+   * @return A gen of T
+   */
+  public static <T> Gen<T> frequency(List<Pair<Integer, Gen<T>>> weightedGens) {
+    return FrequencyGen.fromList(false, weightedGens);
+  }
+
+  /**
+   * Returns a generator that provides a value from a generator chosen with probability
+   * in proportion to the weight supplied in the {@link Pair} with it. This generator
+   * does not shrink, and will always pick generators in proportion to their weight.
+   * At least one generator must have a positive weight and non-positive generators will never
+   * be chosen.
+   *
+   * @param mandatory Generator to sample from
+   * @param others Other generators to sample
+   * @param <T> Type to generate
+   * @return A gen of T
+   */
+  @SafeVarargs
+  public static <T> Gen<T> frequencyWithNoShrinkPoint(Pair<Integer, Gen<T>> mandatory,
+                                                          Pair<Integer, Gen<T>> ... others) {
+    return frequencyWithNoShrinkPoint(
+        FrequencyGen.makeGeneratorList(mandatory, others));
+  }
+
+  /**
+   * Returns a generator that provides a value from a generator chosen with probability
+   * in proportion to the weight supplied in the {@link Pair} with it. This generator
+   * does not shrink, and will always pick generators in proportion to their weight.
+   * At least one generator must have a positive weight and non-positive generators will never
+   * be chosen.
+   *
+   * @param weightedGens pairs of weight and generators to sample in proportion to their weighting
+   * @param <T> Type to generate
+   * @return A gen of T
+   */
+  public static <T> Gen<T> frequencyWithNoShrinkPoint(List<Pair<Integer, Gen<T>>> weightedGens) {
+    return FrequencyGen.fromList(true, weightedGens);
+  }
+
+  static class FrequencyGen<T> implements Gen<T>
+  {
+    private final NavigableMap<Integer, Gen<T>> weightedMap;
+    private final Gen<Integer> indexGen;
+
+    private FrequencyGen(Gen<Integer> indexGen, NavigableMap<Integer, Gen<T>> weightedMap) {
+      this.weightedMap = weightedMap;
+      this.indexGen = indexGen;
+    }
+
+    static <T> List<Pair<Integer, Gen<T>>> makeGeneratorList(Pair<Integer, Gen<T>> mandatory,
+                                                             Pair<Integer, Gen<T>>[] others) {
+      List<Pair<Integer,Gen<T>>> ts = new ArrayList<>(others.length + 1);
+      ts.add(mandatory);
+      Collections.addAll(ts, others);
+      return ts;
+    }
+
+    /* First the generator normalizes the weights and their total by the greatest common factor
+     * to keep integers small and improve the chance of moving to a new generator as the
+     * index generator shrinks.
+     *
+     * Then assigns each generator a range of integers according to their normalized weight
+     * For example, with three normalized weighted generators {3, g1}, {4, g2}, {5, g3},
+     * total 12 it assigns [0, 2] to g1, [3, 6] to g2, [7, 11] to g3.
+     *
+     * At generation time, the generator picks an integer between [0, total weight) and finds
+     * the generator responsible for the range.
+     */
+    @SuppressWarnings("unchecked")
+    static <T> FrequencyGen<T> fromList(boolean withNoShrinkPoint, List<Pair<Integer, Gen<T>>> ts) {
+      if (ts.size() < 1) {
+        throw new IllegalArgumentException("List of generators must not be empty");
+      }
+      /* Calculate the total unadjusted weights, and the largest common factor
+       * between all of the weights and the total, so they can be reduced to the smallest.
+       * It ignores non-positive weights to make it easy to disable generators while developing
+       * properties.
+       */
+      long unadjustedTotalWeights = 0;
+      long commonFactor = 0;
+      for (Pair<Integer,Gen<T>> pair : ts) {
+        int weight = pair._1;
+        if (weight <= 0)
+          continue;
+
+        if (unadjustedTotalWeights == 0) {
+          commonFactor = weight;
+        } else {
+          commonFactor = gcd(commonFactor, weight);
+        }
+        unadjustedTotalWeights += weight;
+      }
+      if (unadjustedTotalWeights == 0) {
+        throw new IllegalArgumentException("At least one generator must have a positive weight");
+      }
+      commonFactor = gcd(commonFactor, unadjustedTotalWeights);
+
+      /* Build a tree map with the key as the first integer assigned in the range,
+       * floorEntry will pick the 'the greatest key less than or equal to the given key',
+       * which will find the right generator for the range.
+       */
+      NavigableMap<Integer, Gen<T>> weightedMap = new TreeMap<>();
+      int nextStart = 0;
+      for (Pair<Integer,Gen<T>> pair : ts) {
+        int weight = pair._1;
+        if (weight <= 0)
+          continue;
+
+        weightedMap.put(nextStart, pair._2);
+        nextStart += weight / commonFactor;
+      }
+      final int upperRange = (int) (unadjustedTotalWeights / commonFactor) - 1;
+
+      Gen<Integer> indexGen = withNoShrinkPoint ? rangeWithNoShrinkPoint(0, upperRange): range(0, upperRange);
+
+      return new FrequencyGen(indexGen, weightedMap);
+    }
+
+    @Override
+    public T generate(RandomnessSource prng) {
+      return weightedMap.floorEntry(indexGen.generate(prng)).getValue().generate(prng);
+    }
+
+    @Override
+    public String asString(T t) {
+      return weightedMap.get(0).asString(t);
+    }
+
+    private static long gcd(long a, long b)
+    {
+      return BigInteger.valueOf(a).gcd(BigInteger.valueOf(b)).longValue();
+    }
+  }
+
+  /**
    * Inclusive integer range that shrinks towards 0
    * @param startInclusive start
    * @param endInclusive end
@@ -107,7 +270,7 @@ public class Generate {
    * @return A Gen of Integers
    */
   public static Gen<Integer> rangeWithNoShrinkPoint(final int startInclusive,
-      final int endInclusive) {
+                                                     final int endInclusive) {
     return td -> Integer.valueOf((int)td.next(Constraint.between(startInclusive, endInclusive).withNoShrinkPoint()));
   }
   

--- a/core/src/test/java/org/quicktheories/generators/GenerateTest.java
+++ b/core/src/test/java/org/quicktheories/generators/GenerateTest.java
@@ -3,7 +3,13 @@ package org.quicktheories.generators;
 import static org.quicktheories.impl.GenAssert.assertThatGenerator;
 
 import org.junit.Test;
+import org.quicktheories.api.Pair;
 import org.quicktheories.core.Gen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class GenerateTest {
 
@@ -21,4 +27,66 @@ public class GenerateTest {
     assertThatGenerator(testee).generatesAllOfWithNSamples(samples, 1,2,3);
   }
 
+  @Test
+  public void frequencyZeroWeightsAreNeverPicked() {
+    int samples = 6;
+    Gen<Integer> testee = Generate.frequency(
+        Pair.of(0,  Generate.constant(1)),
+        Pair.of(15, Generate.constant(2)),
+        Pair.of(30, Generate.constant(3)));
+
+    assertThatGenerator(testee).generatesAllOfWithNSamples(samples, 2, 3);
+  }
+
+  @Test
+  public void frequencyMustHaveAtLeastOneEntry() {
+    List<Pair<Integer,Gen<Integer>>> emptyList = new ArrayList<>();
+    Throwable thrown = org.assertj.core.api.Assertions.catchThrowable(() ->
+        Generate.frequency(emptyList));
+    org.assertj.core.api.Assertions.assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasNoCause()
+        .hasMessage("List of generators must not be empty");
+  }
+
+  @Test
+  public void frequencyMustHaveOnePositiveWeight() {
+    Throwable thrown = org.assertj.core.api.Assertions.catchThrowable(() ->
+        Generate.frequency(Arrays.asList(Pair.of(-1,  Generate.constant(1)),
+            Pair.of(0, Generate.constant(2)),
+            Pair.of(0, Generate.constant(3)))));
+    org.assertj.core.api.Assertions.assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasNoCause()
+        .hasMessage("At least one generator must have a positive weight");
+  }
+
+  @Test
+  public void oneOfGeneratesByWeightPicked() {
+    Gen<Integer> testee = Generate.frequency(
+        Pair.of(1, Generate.constant(1)),
+        Pair.of(2, Generate.constant(2)),
+        Pair.of(3, Generate.constant(3)));
+
+    assertThatGenerator(testee).generatesInProportion(
+        Pair.of(1, 1.0/6.0), Pair.of(2, 2.0/6.0), Pair.of(3, 3.0/6.0));
+  }
+
+  @Test
+  public void frequencyWithNoShrinkPointHasNoShrinkPoint() {
+    Gen<Integer> testee = Generate.frequencyWithNoShrinkPoint(
+        Arrays.asList(Pair.of(1,  Generate.constant(1)),
+            Pair.of(10, Generate.constant(2)),
+            Pair.of(100, Generate.constant(3))));
+    assertThatGenerator(testee).hasNoShrinkPoint();
+  }
+
+  @Test
+  public void frequencyVarArgsWithNoShrinkPointHasNoShrinkPoint() {
+    Gen<Integer> testee = Generate.frequencyWithNoShrinkPoint(
+        Pair.of(1,  Generate.constant(1)),
+        Pair.of(10, Generate.constant(2)),
+        Pair.of(100, Generate.constant(3)));
+    assertThatGenerator(testee).hasNoShrinkPoint();
+  }
 }


### PR DESCRIPTION
Introduces a new generator `frequency` that works similar to `oneOf`, but each generator passed to it also gets a weight, and the resulting output is generated in proportion to the weights supplied.

Also includes a version with no shrink point which is useful for generating command sequences.